### PR TITLE
Update example events JSON blob

### DIFF
--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -31,4 +31,4 @@ format:
 }
 ```
 
-
+The events that can be received using this can be seen [here](/engine/reference/commandline/events/#object-types).

--- a/compose/reference/events.md
+++ b/compose/reference/events.md
@@ -19,10 +19,16 @@ format:
 
 ```
 {
-    "service": "web",
-    "event": "create",
-    "container": "213cf75fc39a",
-    "image": "alpine:edge",
     "time": "2015-11-20T18:01:03.615550",
+    "type": "container",
+    "action": "create",
+    "id": "213cf7...5fc39a",
+    "service": "web",
+    "attributes": {
+        "name": "application_web_1",
+        "image": "alpine:edge",
+    }
 }
 ```
+
+


### PR DESCRIPTION
### Proposed changes

The example JSON blob given doesn't match up with the values I experience when running `docker-compose events` myself, so I'm updating the documentation to save someone else some time. In addition, the events are listed in the API reference, so I've added a link there for convenience.
